### PR TITLE
COMP: Fix macOS GitHub workflow using always available runner

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2022]
+        os: [ubuntu-20.04, macos-latest, windows-2022]
         include:
           - os: ubuntu-20.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-          - os: macos-10.15
+          - os: macos-latest
             c-compiler: "clang"
             cxx-compiler: "clang++"
           - os: windows-2022


### PR DESCRIPTION
The "macos-10.15" runner was removed in August 2022

Update to use "macos-latest" to match the runner used in ClinicalGraphics/VTKU3DExporter

See https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/