### PR TITLE
Tweak configure and build output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,6 @@ option(U3D_BUILD_SAMPLES "Build HelloU3DWorld and IDTFGen" ON)
 # there were real problems with cpuid on Ubuntu 13.04 i386
 add_definitions(-DU3D_NO_ASM)
 
-if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-  set(CMAKE_VERBOSE_MAKEFILE ON)
-endif()
-
 # add debug definitions
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
   add_definitions(-D_DEBUG -DDEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,6 @@ if(UNIX AND NOT APPLE)
   set(U3D_PLATFORM Lin32)
 endif()
 
-message(STATUS "U3D_SHARED: " ${U3D_SHARED})
-
 if(U3D_SHARED)
   if(NOT LIB_DESTINATION)
     set(LIB_DESTINATION lib)
@@ -125,6 +123,9 @@ else()
   #============================================================================
   # zlib
   #============================================================================
+
+  message(STATUS "")
+  message(STATUS "Configuring packaged zlib library")
 
   include(CheckTypeSize)
   include(CheckFunctionExists)
@@ -207,6 +208,9 @@ else()
   # png
   #============================================================================
 
+  message(STATUS "")
+  message(STATUS "Configuring packaged png library")
+
   if(NOT WIN32)
     find_library(M_LIBRARY
       NAMES m
@@ -264,6 +268,9 @@ else()
   #============================================================================
   # jpeg
   #============================================================================
+
+  message(STATUS "")
+  message(STATUS "Configuring packaged jpeg library")
 
   check_include_file(stdlib.h HAVE_STDLIB_H)
 
@@ -366,8 +373,18 @@ else()
 
 endif()
 
-message(STATUS "CMAKE_INSTALL_PREFIX:         " ${CMAKE_INSTALL_PREFIX})
-message(STATUS "LIB_DESTINATION:         " ${LIB_DESTINATION})
+message(STATUS "")
+message(STATUS "U3D_SHARED:              ${U3D_SHARED}")
+message(STATUS "U3D_BUILD_IDTFConverter: ${U3D_BUILD_IDTFConverter}")
+message(STATUS "U3D_BUILD_SAMPLES:       ${U3D_BUILD_SAMPLES}")
+message(STATUS "CMAKE_INSTALL_PREFIX:    ${CMAKE_INSTALL_PREFIX}")
+message(STATUS "LIB_DESTINATION:         ${LIB_DESTINATION}")
+message(STATUS "BIN_DESTINATION:         ${BIN_DESTINATION}")
+message(STATUS "INCLUDE_DESTINATION:     ${INCLUDE_DESTINATION}")
+message(STATUS "PLUGIN_DESTINATION:      ${PLUGIN_DESTINATION}")
+message(STATUS "SAMPLE_DESTINATION:      ${SAMPLE_DESTINATION}")
+message(STATUS "DOC_DESTINATION:         ${DOC_DESTINATION}")
+message(STATUS "")
 
 # include_directories(
 #   RTL/Component/Include


### PR DESCRIPTION
Example of configure output after integrating these changes:

```
$ cmake \
  -DU3D_SHARED:BOOL=OFF \
  -DU3D_BUILD_IDTFConverter:BOOL=OFF \
  -DU3D_BUILD_SAMPLES:BOOL=OFF \
  ../u3d
-- The C compiler identification is GNU 9.4.0
-- ...
-- Detecting CXX compile features - done
-- RELEASE BUILD
-- 
-- Configuring packaged zlib library
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- ...
-- 
-- Configuring packaged png library
-- 
-- Configuring packaged jpeg library
-- Looking for stdlib.h
-- Looking for stdlib.h - found
-- 
-- U3D_SHARED:              OFF
-- U3D_BUILD_IDTFConverter: OFF
-- U3D_BUILD_SAMPLES:       OFF
-- CMAKE_INSTALL_PREFIX:    /usr/local
-- LIB_DESTINATION:         u3d
-- BIN_DESTINATION:         u3d
-- INCLUDE_DESTINATION:     u3d/include
-- PLUGIN_DESTINATION:      u3d
-- SAMPLE_DESTINATION:      u3d/samples
-- DOC_DESTINATION:         u3d/docs
-- 
-- Configuring done
-- Generating done
-- Build files have been written to: /path/to/u3d-Release
```