### PR TITLE
COMP: Fix -Wcatch-value warnings

### DIFF
--- a/RTL/Component/BitStream/CIFXBitStreamX.cpp
+++ b/RTL/Component/BitStream/CIFXBitStreamX.cpp
@@ -200,7 +200,7 @@ void CIFXBitStreamX::WriteIFXStringX(IFXString& rString)
 			IFXDELETE_ARRAY(pValue);
 		}
 	}
-	catch(IFXException e)
+	catch(IFXException& e)
 	{
 		IFXDELETE_ARRAY(pValue);
 		throw e;
@@ -304,7 +304,7 @@ void CIFXBitStreamX::ReadIFXStringX(IFXString& rString)
 
 		IFXDELETE_ARRAY(pValue);
 	}
-	catch(IFXException e) 
+	catch(IFXException& e)
 	{
 		IFXDELETE_ARRAY(pValue);
 		throw e;
@@ -920,7 +920,7 @@ void CIFXBitStreamX::AllocateDataBuffer(U32 uSize)
 		IFXDELETE_ARRAY(puOldData);
 	}
 
-	catch(IFXException e)
+	catch(IFXException& e)
 	{
 		IFXDELETE_ARRAY(puOldData);
 		throw e ;

--- a/RTL/Component/BitStream/CIFXDataBlockX.cpp
+++ b/RTL/Component/BitStream/CIFXDataBlockX.cpp
@@ -60,7 +60,7 @@ IFXRESULT CIFXDataBlockX::SetSize( U32 count )
     SetSizeX(count);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -103,7 +103,7 @@ IFXRESULT CIFXDataBlockX::GetSize( U32* pCount )
     GetSizeX(*pCount);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -139,7 +139,7 @@ IFXRESULT CIFXDataBlockX::GetTotalSize( U64* pCount )
     GetTotalSizeX(*pCount);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -174,7 +174,7 @@ IFXRESULT CIFXDataBlockX::GetAvailableSize( U64* pCount )
     GetAvailableSizeX(*pCount);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -200,7 +200,7 @@ IFXRESULT CIFXDataBlockX::SetBlockType( U32 BlockType )
     SetBlockTypeX(BlockType);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -234,7 +234,7 @@ IFXRESULT CIFXDataBlockX::GetBlockType( U32* pBlockType )
     GetBlockTypeX(*pBlockType);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -267,7 +267,7 @@ IFXRESULT CIFXDataBlockX::GetPointer( U8** ppData )
     GetPointerX(*ppData);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -295,7 +295,7 @@ IFXRESULT CIFXDataBlockX::Read( U8* pBytes, U64 position, U32 count )
     ReadX(pBytes,position,count,rc);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 
@@ -331,7 +331,7 @@ IFXRESULT CIFXDataBlockX::Write( U8* pBytes, U64 position, U32 count )
     WriteX( pBytes,position,count);
   }
 
-  catch(IFXException e) {
+  catch(IFXException& e) {
     rc = e.GetIFXResult();
   }
 

--- a/RTL/Component/Exporting/CIFXAuthorCLODEncoderX_P.cpp
+++ b/RTL/Component/Exporting/CIFXAuthorCLODEncoderX_P.cpp
@@ -260,7 +260,7 @@ void CIFXAuthorCLODEncoderX::MakeAuthorCLODProgressiveGeometryBlocksX(IFXString 
 						// Free tally array
 						IFXDELETE_ARRAY(puSplitPositionCandidates);
 					}
-					catch (IFXException e) {
+					catch (IFXException& e) {
 						// Free tally array
 						IFXDELETE_ARRAY(puSplitPositionCandidates);
 						throw(e);

--- a/RTL/Component/Exporting/CIFXAuthorGeomCompiler.cpp
+++ b/RTL/Component/Exporting/CIFXAuthorGeomCompiler.cpp
@@ -453,7 +453,7 @@ IFXRESULT CIFXAuthorGeomCompiler::Compile(IFXString& rName,
 					}
 				}
 			}
-			catch(IFXException e)
+			catch(IFXException& e)
 			{
 				result = e.GetIFXResult();
 			}
@@ -550,7 +550,7 @@ IFXRESULT CIFXAuthorGeomCompiler::Compile(IFXString& rName,
 									m_pParams->CompressParams.bExcludeNormals);
 				}
 			}
-			catch(IFXException e)
+			catch(IFXException& e)
 			{
 				result = e.GetIFXResult();
 			}
@@ -602,7 +602,7 @@ IFXRESULT CIFXAuthorGeomCompiler::Compile(IFXString& rName,
 			}
 
 		}
-		catch(IFXException e)
+		catch(IFXException& e)
 		{
 			result = e.GetIFXResult();
 		}

--- a/RTL/Component/Exporting/CIFXStdioWriteBufferX.cpp
+++ b/RTL/Component/Exporting/CIFXStdioWriteBufferX.cpp
@@ -50,7 +50,7 @@ IFXRESULT CIFXStdioWriteBufferX::Write( U8* pBytes, U64 position, U32 count )
 		WriteX(pBytes,position,count);
 	}
 
-	catch(IFXException e)
+	catch(IFXException& e)
 	{
 		rc = e.GetIFXResult();
 	}

--- a/RTL/Component/Exporting/CIFXWriteManager.cpp
+++ b/RTL/Component/Exporting/CIFXWriteManager.cpp
@@ -223,7 +223,7 @@ IFXRESULT CIFXWriteManager::Initialize( IFXCoreServices *pCoreServices )
 		IFXCHECKX( m_pCoreServices->GetSceneGraph( IID_IFXSceneGraph, (void**) &m_pScenegraph ) );
 	}
 
-	catch ( IFXException e )
+	catch ( IFXException& e )
 	{
 		rc = e.GetIFXResult();
 	}
@@ -313,7 +313,7 @@ IFXRESULT CIFXWriteManager::Write( IFXWriteBuffer* pWriteBuffer, IFXExportOption
 		IFXRELEASE( m_pPriorityQueue );
 		IFXRELEASE( m_pBlockWriter );
 	}
-	catch(IFXException e)
+	catch(IFXException& e)
 	{
 		rc = e.GetIFXResult();
 
@@ -369,7 +369,7 @@ IFXRESULT CIFXWriteManager::SetQualityFactor( U32       uQualityFactor,
 			SetQualityOnPalette( uQualityFactor, IFXSceneGraph::TEXTURE );
 		}
 	}
-	catch ( IFXException e )
+	catch ( IFXException& e )
 	{
 		rc = e.GetIFXResult();
 	}

--- a/RTL/Component/Importing/CIFXStdioReadBufferX.cpp
+++ b/RTL/Component/Importing/CIFXStdioReadBufferX.cpp
@@ -53,7 +53,7 @@ IFXRESULT CIFXStdioReadBufferX::Read( U8* pBytes, U64 position, U32 count )
 		}
 	}
 
-	catch(IFXException e)
+	catch(IFXException& e)
 	{
 		rc = e.GetIFXResult();
 	}
@@ -111,7 +111,7 @@ IFXRESULT CIFXStdioReadBufferX::GetTotalSize( U64* pCount )
 		GetTotalSizeX(*pCount);
 	}
 
-	catch(IFXException e) {
+	catch(IFXException& e) {
 		rc = e.GetIFXResult();
 	}
 
@@ -156,7 +156,7 @@ IFXRESULT CIFXStdioReadBufferX::GetAvailableSize( U64* pCount )
 		GetAvailableSizeX(*pCount);
 	}
 
-	catch (IFXException e) {
+	catch (IFXException& e) {
 		rc = e.GetIFXResult();
 	}
 

--- a/RTL/Component/Texture/CIFXTextureObject.cpp
+++ b/RTL/Component/Texture/CIFXTextureObject.cpp
@@ -419,7 +419,7 @@ void CIFXTextureObject::SetPriority(
         m_bBlockQueueDirty = FALSE;
       }
 
-      catch (IFXException e) 
+      catch (IFXException& e)
 	  {
         ; // Catch any IFXException and do nothing with it
       }
@@ -1567,7 +1567,7 @@ IFXRESULT CIFXTextureObject::ConstructQueueFromImage(
 
 	}
 
-	catch (IFXException e) 
+	catch (IFXException& e)
 	{
 		iResult = e.GetIFXResult();
 	}


### PR DESCRIPTION
See https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Re-exception-ref

Fix warning like the following:

```
/path/tou3d/RTL/Component/Exporting/CIFXAuthorGeomCompiler.cpp:605:22: warning: catching polymorphic type ‘class IFXException’ by value [-Wcatch-value=]
  605 |   catch(IFXException e)
      |                      ^

```